### PR TITLE
Fix missing semicolon in configurations insert statement

### DIFF
--- a/sql/jsonair.sql
+++ b/sql/jsonair.sql
@@ -50,7 +50,7 @@ CREATE TABLE `configurations` (
 LOCK TABLES `configurations` WRITE;
 
 INSERT INTO `configurations` VALUES
-(1,'','RELOADKEY','DEBUGLEVEL','testsub','test.config','{\"config\":\"some value\"}', NOW(), NOW() )
+(1,'','RELOADKEY','DEBUGLEVEL','testsub','test.config','{\"config\":\"some value\"}', NOW(), NOW() );
 
 UNLOCK TABLES;
 


### PR DESCRIPTION
This update corrects a SQL syntax issue in the configurations insert script by adding the missing semicolon at the end of the INSERT INTO statement.

The original script locked the configurations table and attempted to insert a new configuration record, but the INSERT statement was missing a terminating semicolon before UNLOCK TABLES. This could cause the script to fail or prevent the table from being unlocked properly.

Corrected SQL:

LOCK TABLES `configurations` WRITE;

INSERT INTO `configurations` VALUES
(1,'','RELOADKEY','DEBUGLEVEL','testsub','test.config','{\"config\":\"some value\"}', NOW(), NOW() );

UNLOCK TABLES;

Change Made:

- (1,'','RELOADKEY','DEBUGLEVEL','testsub','test.config','{\"config\":\"some value\"}', NOW(), NOW() )
+ (1,'','RELOADKEY','DEBUGLEVEL','testsub','test.config','{\"config\":\"some value\"}', NOW(), NOW() );